### PR TITLE
perf: optimise 8/16-blit scalar routines

### DIFF
--- a/include/meen_hw/MH_II8080ArcadeIO.h
+++ b/include/meen_hw/MH_II8080ArcadeIO.h
@@ -164,7 +164,7 @@ namespace meen_hw
 
 			@remark					No boundry checks are performed. It is expected that
 									the dstVRAM is allocted using the GetVideoWidth and
-									GetVideoHeight methods to determine a minimum allocaion
+									GetVideoHeight methods to determine a minimum allocation
 									size.
 		*/
 		virtual void BlitVRAM(std::span<uint8_t> dstVRAM, int dstVRAMRowBytes, std::span<uint8_t> srcVRAM) = 0;


### PR DESCRIPTION
Re-wrote the decompressVram method for a near 40% performance boost when running the i8080-arcade project on a pico rp2040 with st7789 lcd. Frames per second has increased from 36 to 50. More optimisations are required (future pr) as we need to get to at least 60.