### PR TITLE
#36 feat: blit to memory of varying size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 0.3.0
-* SetOptions option `bpp` now supports 16 for 16bpp
-  blits via BlitVRAM.
-* Change blit flag Rgb332 to bpp8.
-* Added blit flags bpp16 and Upright16bpp for
+* SetOptions option `bpp` now supports `16` for `16bpp`
+  blits via `MH_I8080ArcadeIO::BlitVRAM`.
+* Change blit flag `Rgb332` to `bpp8`.
+* Added blit flags `bpp16` and `Upright16bpp` for
   16bit blit support.
+* The `MH_I8080ArcadeIO::BlitVRAM` method can now blit
+  from sources to destinations of varying dimensions.
+* Fixed a bug where parsing the `colour` option `blue`
+  would fail.
 
 0.2.1 [04/09/24]
 * Updated the install instructions for new meen

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Machine Emulator ENgine Hardware is a collection of 8bit emulated hardwares desi
 
 Supported hardwares:
 
-- i8080 arcade - hardware emulation based on the 1978 Midway/Taito Space Invaders arcade machine. Along with the original Space Invaders title, this emulated hardware is also compatible with Lunar Rescue (1979), Balloon Bomber (1980) and Space Invaders Part II/Deluxe (1980). **NOTE**: currently does not support emulated audio, the consuming application needs to provide audio samples.
+- i8080 arcade - hardware emulation based on the 1978 Midway/Taito Space Invaders arcade machine. Along with the original Space Invaders title, this emulated hardware is also compatible with Lunar Rescue (1979), Balloon Bomber (1980) and Space Invaders Part II/Deluxe (1980). It contains helper methods for blitting the native 1bpp cocktail orientation video ram to to 8/16 bit buffers in either native (cocktail) or upright orientations.<br>
+**NOTE**: currently does not support emulated audio, the consuming application needs to provide audio samples.
 
 ### Compilation
 

--- a/include/meen_hw/MH_II8080ArcadeIO.h
+++ b/include/meen_hw/MH_II8080ArcadeIO.h
@@ -162,32 +162,9 @@ namespace meen_hw
 			@param	dstVRAMRowBytes	The width of each dst vram scanline in bytes.
 			@param	srcVRAM			The video ram to copy.
 
-			@remark					No boundry checks are performed. It is expected that
-									the dstVRAM is allocted using the GetVideoWidth and
-									GetVideoHeight methods to determine a minimum allocation
-									size.
+			@remark					The srcVRAM is assumed to be contiguous without padding.
 		*/
-		virtual void BlitVRAM(std::span<uint8_t> dstVRAM, int dstVRAMRowBytes, std::span<uint8_t> srcVRAM) = 0;
-
-		/** Output video width in pixels
-
-			The option `blit-orientation` will determine this value. For a cocktail
-			orientation (default), it will be 256 pixels. For an upright orientation
-			it will be 224 pixels.
-
-			@return				The width of the dstVRAM passed to BlitVRAM. 
-		*/
-		virtual int GetVRAMWidth() const = 0;
-
-		/** Output video height in pixels
-
-			The option `blit-orientation` will determine this value. For a cocktail
-			orientation (default), it will be 224 pixels. For an upright orientation
-			it will be 256 pixels.
-
-			@return				The height of the dstVRAM passed to BlitVRAM.
-		*/
-		virtual int GetVRAMHeight() const = 0;
+		virtual void BlitVRAM(std::span<uint8_t> dst, int dstWidth, int dstRowBytes, std::span<uint8_t> src, int srcWidth) = 0;
 
 		virtual ~MH_II8080ArcadeIO() = default;
 	};

--- a/include/meen_hw/i8080_arcade/MH_I8080ArcadeIO.h
+++ b/include/meen_hw/i8080_arcade/MH_I8080ArcadeIO.h
@@ -144,25 +144,13 @@ namespace meen_hw::i8080_arcade
 		
 			@see MH_II8080ArcadeIO::BlitVRAM
 		*/
-		void BlitVRAM(std::span<uint8_t> dst, int rowBytes, std::span<uint8_t> src) final;
+		void BlitVRAM(std::span<uint8_t> dst, int dstWidth, int dstRowBytes, std::span<uint8_t> src, int srcWidth) final;
 
 		/** Blit options
 
 			@see MH_II8080ArcadeIO::BlitVRAM
 		*/
 		std::error_code SetOptions(const char* options) final;
-
-		/** Output video width
-
-			@see MH_II8080ArcadeIO::GetVRAMWidth
-		*/
-		int GetVRAMWidth() const final;
-
-		/** Output video height
-
-			@see MH_II8080ArcadeIO::GetVRAMHeight
-		*/
-		int GetVRAMHeight() const final;
 	};
 } // namespace meen_hw::i8080_arcade
 

--- a/source/i8080_arcade/MH_I8080ArcadeIO.cpp
+++ b/source/i8080_arcade/MH_I8080ArcadeIO.cpp
@@ -126,13 +126,13 @@ namespace meen_hw::i8080_arcade
 		return isr;
 	}
 
-	void MH_I8080ArcadeIO::BlitVRAM(std::span<uint8_t> dst, int rowBytes, std::span<uint8_t> src)
+	void MH_I8080ArcadeIO::BlitVRAM(std::span<uint8_t> dst, int dstWidth, int dstRowBytes, std::span<uint8_t> src, int srcWidth)
 	{
-		assert(dst.size() >= src.size());
+		assert(dstWidth * (dst.size() / dstRowBytes) >= src.size());
 
-		auto decompressVram = [src, dst, rowBytes, colour = colour_]<class T, bool cocktail>
+		auto decompressVram = [src, dst, dstWidth, dstRowBytes, colour = colour_]<class T, bool cocktail>
 		{
-			auto rb = rowBytes / sizeof(T);
+			auto rb = dstRowBytes / sizeof(T);
 			auto sb = src.begin();
 			T* ds;
 			int width;
@@ -140,15 +140,15 @@ namespace meen_hw::i8080_arcade
 
 			if constexpr (cocktail == true)
 			{
-				width = 256;
-				height = dst.size() / rowBytes;
+				width = dstWidth;
+				height = dst.size() / dstRowBytes;
 				ds = std::bit_cast<T*>(dst.data());
 			}
 			else
 			{
-				width = dst.size() / rowBytes;
-				height = 224;
-				ds = std::bit_cast<T*>(dst.data()) + (rb * (256 - 1));
+				width = dst.size() / dstRowBytes;
+				height = dstWidth;
+				ds = std::bit_cast<T*>(dst.data()) + (rb * (width - 1));
 			}
 
 			auto de = ds;
@@ -192,14 +192,14 @@ namespace meen_hw::i8080_arcade
 		{
 			case BlitFlags::Upright:
 			{
-				static constexpr int srcWidth = 32;
-				static constexpr int srcWidthMinus1 = srcWidth - 1;
+				const int srcWidthMinus1 = srcWidth - 1;
 				// Need to skip an additional 7 rows once the vertical sampling is complete.
-				static constexpr int srcRowSkip = srcWidth * 7;
+				const int srcRowSkip = srcWidth * 7;
 
 				auto begin = src.begin();
 				auto end = src.end();
-				auto start = dst.data() + rowBytes * (256 - 1);
+				auto height = dst.size() / dstRowBytes;
+				auto start = dst.data() + dstRowBytes * (height - 1);
 				auto ptr = start;
 
 				while (begin < end)
@@ -217,20 +217,17 @@ namespace meen_hw::i8080_arcade
 						*ptr = byte;
 
 						// Move to the previous row, else the next column
-						ptr - rowBytes >= dst.data() ? ptr -= rowBytes : ptr = ++start;
+						ptr - dstRowBytes >= dst.data() ? ptr -= dstRowBytes : ptr = ++start;
 					}
 
 					begin++;
-
-					// Since we sample 8 vertical pixels we need to skip another 7 rows when we get to the end of the current row.
-					// TODO: mem pool frames need to be 32 bit aligned, then we don't have to subtract src, ie; just for (begin & (width_ - 1)) == 0
 					begin += (((begin - src.begin() & srcWidthMinus1) == 0) * srcRowSkip);
 				}
 				break;
 			}
 			case BlitFlags::Native:
 			{
-				if(rowBytes == 32)
+				if((dstRowBytes == dstWidth) && (dstWidth == srcWidth)) // We don't support source padding, so if the destination is not padded, do a straight copy
 				{
 					std::copy(src.begin(), src.end(), dst.begin());
 				}
@@ -240,11 +237,11 @@ namespace meen_hw::i8080_arcade
 					auto s = src.begin();
 
 					// copy out each scanline
-					while(s < src.end())
+					while(d < dst.end() && s < src.end())
 					{
-						std::copy_n(s, 32, d);
-						d += rowBytes;
-						s += 32;
+						std::copy_n(s, srcWidth, d);
+						d += dstRowBytes;
+						s += srcWidth;
 					}
 				}
 				break;
@@ -345,40 +342,36 @@ namespace meen_hw::i8080_arcade
 #else
 				auto colour = kv.value().as<std::string_view>();
 #endif
-				auto [ptr, errc] = std::from_chars(colour.data(), colour.data() + colour.size(), colour_, 16);
 
-				if (errc != std::errc())
+				if (colour == "red")
 				{
-					if (colour == "red")
-					{
-						colour_ = 0xF880;
-					}
-					else if (colour == "green")
-					{
-						colour_ = 0x07F4;
-					}
-					else if (colour == "blue")
-					{
-						colour_ = 0x0007;
-					}
-					else if (colour == "white")
-					{
-						colour_ = 0xFFFF;
-					}
-					else if (colour == "random")
-					{
-						srand(time(nullptr));
-						colour_ = rand() % 65535 + rand() % 255;
-					}
-					else
+					colour_ = 0xF880;
+				}
+				else if (colour == "green")
+				{
+					colour_ = 0x07F4;
+				}
+				else if (colour == "blue")
+				{
+					colour_ = 0x0007;
+				}
+				else if (colour == "white")
+				{
+					colour_ = 0xFFFF;
+				}
+				else if (colour == "random")
+				{
+					srand(time(nullptr));
+					colour_ = rand() % 65535 + rand() % 255;
+				}
+				else
+				{
+					auto [ptr, errc] = std::from_chars(colour.data(), colour.data() + colour.size(), colour_, 16);
+
+					if (errc != std::errc() || *ptr != '\0')
 					{
 						err = meen_hw::make_error_code(errc::colour);
 					}
-				}
-				else if (*ptr != '\0')
-				{
-					// we parsed something but there is still left over text
-					err = meen_hw::make_error_code(errc::colour);
 				}
 			}
 			else if(key == "orientation")
@@ -409,15 +402,5 @@ namespace meen_hw::i8080_arcade
 		}
 
 		return err;
-	}
-
-	int MH_I8080ArcadeIO::GetVRAMWidth() const
-	{
-		return blitMode_ & BlitFlags::Upright ? 224 : 256;
-	}
-
-	int MH_I8080ArcadeIO::GetVRAMHeight() const
-	{
-		return blitMode_ & BlitFlags::Upright ? 256 : 224;
 	}
 } // namespace meen_hw::i8080_arcade

--- a/tests/meen_hw_test/source/MeenHwGTest.cpp
+++ b/tests/meen_hw_test/source/MeenHwGTest.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <algorithm>
 #include <bit>
 #include <gtest/gtest.h>
 #include <vector>
@@ -242,49 +243,47 @@ namespace meen_hw::tests
 	}
 
 	TEST_F(MeenHwTest, SetOptions)
-	{
-		auto checkErrc = [](const std::error_code& ec, bool success, const char* expectedMsg)
-		{
-			if (success == true) EXPECT_FALSE(ec); else EXPECT_TRUE(ec);
-			EXPECT_EQ(expectedMsg, ec.message());
-		};
+	{	
+		// Set invalid options
 
-		EXPECT_NO_THROW
-		(
-			checkErrc(i8080ArcadeIO_->SetOptions("{\"bpp\":2}"), false, "The bpp configuration option is invalid");
-			checkErrc(i8080ArcadeIO_->SetOptions("{\"colour\":\"black\" }"), false, "The colour configuration option is invalid");
-			checkErrc(i8080ArcadeIO_->SetOptions("{\"orientation\":\"up\"}"), false, "The orientation configuration parameter is invalid");
-			checkErrc(i8080ArcadeIO_->SetOptions("syntax-error"), false, "A json parse error occurred while processing the configuration file");
-			checkErrc(i8080ArcadeIO_->SetOptions("{\"bpp\":8,\"colour\":\"random\",\"orientation\":\"cocktail\"}"), true, "Success");
-		);
-	}
+		EXPECT_TRUE(i8080ArcadeIO_->SetOptions("{ \"bpp\":2}"));
+		EXPECT_TRUE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"black\" }"));
+		EXPECT_TRUE(i8080ArcadeIO_->SetOptions("{ \"orientation\":\"up\" }"));
+		EXPECT_TRUE(i8080ArcadeIO_->SetOptions("syntax-error"));
+		
+		// Set valid options
 
-	TEST_F(MeenHwTest, GetVRAMDimensions)
-	{
-		EXPECT_NO_THROW(i8080ArcadeIO_->SetOptions("{\"orientation\":\"cocktail\"}"));
-		EXPECT_EQ(256, i8080ArcadeIO_->GetVRAMWidth());
-		EXPECT_EQ(224, i8080ArcadeIO_->GetVRAMHeight());
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"bpp\":8 }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"bpp\":16 }"));
 
-		EXPECT_NO_THROW(i8080ArcadeIO_->SetOptions("{\"orientation\":\"upright\"}"););
-		EXPECT_EQ(224, i8080ArcadeIO_->GetVRAMWidth());
-		EXPECT_EQ(256, i8080ArcadeIO_->GetVRAMHeight());
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"red\" }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"green\" }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"blue\" }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"white\" }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"random\" }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"colour\":\"CF\" }"));
+
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"orientation\":\"upright\" }"));
+		EXPECT_FALSE(i8080ArcadeIO_->SetOptions("{ \"orientation\":\"cocktail\" }"));
 	}
 
 	TEST_F(MeenHwTest, BlitVRAM)
 	{
-		uint8_t srcVRAM[7168]; // 7168 - width * height @ 1bpp
-		//uint8_t expectedVRAM[57344]; // 57344 - width * height @ 8pp
-		uint8_t expectedVRAM[114688]; // 57344 - width * height @ 16pp
+		std::vector<uint8_t> srcVRAM(7168);//[7168]; // 7168 - width * height @ 1bpp
+		//std::vector<uint8_t> expectedVRAM(57344); // 57344 - width * height @ 8pp
+		std::vector<uint8_t> expectedVRAM(114688);//[114688]; // 57344 - width * height @ 16pp
 
-		auto checkVRAM = [this](std::span<uint8_t> VRAMToBlit, std::span<uint8_t> expectedVRAM, int expectedWidth, int bpp, int padding, int compressed, const char* options)
+		auto checkVRAM = [this](std::span<uint8_t> VRAMToBlit, int width, std::span<uint8_t> expectedVRAM, int expectedWidth, int bpp, int padding, int compressed, const char* options)
 		{
 			// Blit to native format
 			EXPECT_NO_THROW(i8080ArcadeIO_->SetOptions(options));
 			// To get the row bytes we need to shift down 3 (divide by 8) if we are compressed, 0 if we are uncompressed.
-			auto actualRowBytes = ((i8080ArcadeIO_->GetVRAMWidth() >> compressed) + padding) * bpp; // add some padding so the row bytes differs from the expected
-			auto expectedRowBytes = expectedWidth * bpp;
-			auto dstVRAM = std::vector<uint8_t>(actualRowBytes * i8080ArcadeIO_->GetVRAMHeight());
-			EXPECT_NO_THROW(i8080ArcadeIO_->BlitVRAM(std::span(dstVRAM), actualRowBytes, VRAMToBlit));
+
+			auto actualRowBytes = ((width >> compressed) + padding) * bpp; // add some padding so the row bytes differs from the expected
+			auto actualWidth = (width >> compressed); // in pixels
+			auto expectedRowBytes = (width >> compressed) * bpp;
+			auto dstVRAM = std::vector<uint8_t>(actualRowBytes * (VRAMToBlit.size() / (width >> 3)));
+			EXPECT_NO_THROW(i8080ArcadeIO_->BlitVRAM(std::span(dstVRAM), actualWidth, actualRowBytes, VRAMToBlit, 256 >> 3));
 
 			auto expected = expectedVRAM.data();
 			auto actual = dstVRAM.data();
@@ -301,62 +300,62 @@ namespace meen_hw::tests
 
 		// Set the src vram to be blitted to be an alternating black and white scanline pattern
 		// This will act as the expectedVRAM for 1bpp native orientation test
-		for (auto data = srcVRAM; data < srcVRAM + 7168; data += 64)
+		for (auto data = srcVRAM.begin(); data < srcVRAM.end()/* + 7168*/; std::advance(data, 64)/*data += 64*/)
 		{
 			// 32 - compressed row bytes
-			std::fill_n(data, 32, 0x00);
+			std::ranges::fill_n(data, 32, 0x00);
 			std::fill_n(data + 32, 32, 0xFF);
 		}
 
 		// Native blit without padding
-		checkVRAM(std::span(srcVRAM), std::span(srcVRAM), 32, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(srcVRAM), 32, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
 		// Native blit with padding
-		checkVRAM(std::span(srcVRAM), std::span(srcVRAM), 32, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
-		// Vertical black and white bars
-		std::fill(expectedVRAM, expectedVRAM + 7168, 0xAA);
-		// Native bpp blit with upright orientation without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 7168), 28, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
-		// Native bpp blit with upright orientation with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 7168), 28, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(srcVRAM), 32, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
 
-		for (auto data = expectedVRAM; data < expectedVRAM + 57344; data += 512)
+		// Vertical black and white bars
+		std::ranges::fill(expectedVRAM.begin(), expectedVRAM.begin() + 7168, 0xAA);
+		// Native bpp blit with upright orientation without padding
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 7168), 28, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
+		// Native bpp blit with upright orientation with padding
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 7168), 28, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
+
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.begin() + 57344; std::advance(data, 512))//data += 512)
 		{
 			// 256 - 8bpp uncompressed row bytes
-			std::fill_n(data, 256, 0x00);
-			std::fill_n(data + 256, 256, 0xFF);
+			std::ranges::fill_n(data, 256, 0x00);
+			std::ranges::fill_n(data + 256, 256, 0xFF);
 		}
 
 		// Native orientation 8pp blit without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 57344), 256, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM.begin(), 57344), 256, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
 		// Native orientation 8pp blit with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 57344), 256, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM.begin(), 57344), 256, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
 
-		auto data = expectedVRAM;
-		std::fill_n(std::bit_cast<uint16_t*>(data), 28672, 0xFF00);
+		std::ranges::fill_n(std::bit_cast<uint16_t*>(expectedVRAM.data()), 28672, 0xFF00);
 
 		// 8 bpp blit with upright orientation without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 57344), 224, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 57344), 224, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
 		// 8 bpp blit with upright orientation with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 57344), 224, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 57344), 224, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
 
-		for (auto data = expectedVRAM; data < expectedVRAM + 114688; data += 1024)
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.end()/* + 114688*/; std::advance(data, 1024))//data += 1024)
 		{
 			// 512 - 16bpp uncompressed row bytes
-			std::fill_n(data, 512, 0x00);
-			std::fill_n(data + 512, 512, 0xFF);
+			std::ranges::fill_n(data, 512, 0x00);
+			std::ranges::fill_n(data + 512, 512, 0xFF);
 		}
 
 		// Native orientation 16pp blit without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 256, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM), 256, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"cocktail\"}");
 		// Native orientation 16pp blit with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 256, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM), 256, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"cocktail\"}");
 
-		std::fill_n(std::bit_cast<uint32_t*>(data), 28672, 0xFFFF0000);
+		std::ranges::fill_n(std::bit_cast<uint32_t*>(expectedVRAM.data()), 28672, 0xFFFF0000);
 
 		// 16 bpp blit with upright orientation without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 224, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM), 224, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
 		// 16 bpp blit with upright orientation with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 224, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM), 224, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
 	}
 #endif
 

--- a/tests/meen_hw_test/source/MeenHwGTest.cpp
+++ b/tests/meen_hw_test/source/MeenHwGTest.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -269,9 +269,8 @@ namespace meen_hw::tests
 
 	TEST_F(MeenHwTest, BlitVRAM)
 	{
-		std::vector<uint8_t> srcVRAM(7168);//[7168]; // 7168 - width * height @ 1bpp
-		//std::vector<uint8_t> expectedVRAM(57344); // 57344 - width * height @ 8pp
-		std::vector<uint8_t> expectedVRAM(114688);//[114688]; // 57344 - width * height @ 16pp
+		std::vector<uint8_t> srcVRAM(7168); // 7168 - width * height @ 1bpp
+		std::vector<uint8_t> expectedVRAM(114688); // 114688 - width * height @ 16pp
 
 		auto checkVRAM = [this](std::span<uint8_t> VRAMToBlit, int width, std::span<uint8_t> expectedVRAM, int expectedWidth, int bpp, int padding, int compressed, const char* options)
 		{
@@ -300,7 +299,7 @@ namespace meen_hw::tests
 
 		// Set the src vram to be blitted to be an alternating black and white scanline pattern
 		// This will act as the expectedVRAM for 1bpp native orientation test
-		for (auto data = srcVRAM.begin(); data < srcVRAM.end()/* + 7168*/; std::advance(data, 64)/*data += 64*/)
+		for (auto data = srcVRAM.begin(); data < srcVRAM.end(); std::advance(data, 64))
 		{
 			// 32 - compressed row bytes
 			std::ranges::fill_n(data, 32, 0x00);
@@ -338,7 +337,7 @@ namespace meen_hw::tests
 		// 8 bpp blit with upright orientation with padding
 		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 57344), 224, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
 
-		for (auto data = expectedVRAM.begin(); data < expectedVRAM.end()/* + 114688*/; std::advance(data, 1024))//data += 1024)
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.end(); std::advance(data, 1024))
 		{
 			// 512 - 16bpp uncompressed row bytes
 			std::ranges::fill_n(data, 512, 0x00);

--- a/tests/meen_hw_test/source/MeenHwUnityTest.cpp
+++ b/tests/meen_hw_test/source/MeenHwUnityTest.cpp
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <algorithm>
 #include <bit>
 #ifdef ENABLE_MH_RP2040
 #include <pico/stdlib.h>
@@ -248,50 +249,52 @@ namespace meen_hw::tests
 
 	void test_SetOptions()
 	{
-		auto checkErrc = [](const std::error_code& ec, bool success, const char* expectedMsg)
-		{
-			if (success == true) TEST_ASSERT_FALSE(ec); else TEST_ASSERT_TRUE(ec);
-			TEST_ASSERT_EQUAL_STRING(expectedMsg, ec.message().c_str());
-		};
+		// Set invalid options
 
-		checkErrc(i8080ArcadeIO->SetOptions("{\"bpp\":2}"), false, "The bpp configuration option is invalid");
-		checkErrc(i8080ArcadeIO->SetOptions("{\"colour\":\"black\" }"), false, "The colour configuration option is invalid");
-		checkErrc(i8080ArcadeIO->SetOptions("{\"orientation\":\"up\"}"), false, "The orientation configuration parameter is invalid");
-		checkErrc(i8080ArcadeIO->SetOptions("syntax-error"), false, "A json parse error occurred while processing the configuration file");
-		checkErrc(i8080ArcadeIO->SetOptions("{\"bpp\":8,\"colour\":\"random\",\"orientation\":\"cocktail\"}"), true, "Success");
-	}
+		TEST_ASSERT_TRUE(i8080ArcadeIO->SetOptions("{ \"bpp\":2}"));
+		TEST_ASSERT_TRUE(i8080ArcadeIO->SetOptions("{ \"colour\":\"black\" }"));
+		TEST_ASSERT_TRUE(i8080ArcadeIO->SetOptions("{ \"orientation\":\"up\" }"));
+		TEST_ASSERT_TRUE(i8080ArcadeIO->SetOptions("syntax-error"));
+		
+		// Set valid options
 
-	void test_GetVRAMDimensions()
-	{
-		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{\"orientation\":\"cocktail\"}"));
-		TEST_ASSERT_EQUAL_UINT16(256, i8080ArcadeIO->GetVRAMWidth());
-		TEST_ASSERT_EQUAL_UINT16(224, i8080ArcadeIO->GetVRAMHeight());
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"bpp\":8 }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"bpp\":16 }"));
 
-		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{\"orientation\":\"upright\"}"));
-		TEST_ASSERT_EQUAL_UINT16(224, i8080ArcadeIO->GetVRAMWidth());
-		TEST_ASSERT_EQUAL_UINT16(256, i8080ArcadeIO->GetVRAMHeight());
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"colour\":\"red\" }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"colour\":\"green\" }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"colour\":\"blue\" }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"colour\":\"white\" }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"colour\":\"random\" }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"colour\":\"CF\" }"));
+
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"orientation\":\"upright\" }"));
+		TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions("{ \"orientation\":\"cocktail\" }"));
 	}
 
 	void test_BlitVRAM()
 	{
-		uint8_t srcVRAM[7168]; // 7168 - width * height @ 1bpp
-		uint8_t expectedVRAM[57344]; // 57344 - width * height @ 8pp
+		std::vector<uint8_t> srcVRAM(7168);//[7168]; // 7168 - width * height @ 1bpp
+		//std::vector<uint8_t> expectedVRAM(57344); // 57344 - width * height @ 8pp
+		std::vector<uint8_t> expectedVRAM(114688);//[114688]; // 57344 - width * height @ 16pp
 
-		auto checkVRAM = [this](std::span<uint8_t> VRAMToBlit, std::span<uint8_t> expectedVRAM, int expectedWidth, int bpp, int padding, int compressed, const char* options)
+		auto checkVRAM = [](std::span<uint8_t> VRAMToBlit, int width, std::span<uint8_t> expectedVRAM, int expectedWidth, int bpp, int padding, int compressed, const char* options)
 		{
 			// Blit to native format
 			TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions(options));
 			// To get the row bytes we need to shift down 3 (divide by 8) if we are compressed, 0 if we are uncompressed.
-			auto actualRowBytes = ((i8080ArcadeIO_->GetVRAMWidth() >> compressed) + padding) * bpp; // add some padding so the row bytes differs from the expected
-			auto expectedRowBytes = expectedWidth * bpp;
-			auto dstVRAM = std::vector<uint8_t>(actualRowBytes * i8080ArcadeIO_->GetVRAMHeight());
-			i8080ArcadeIO_->BlitVRAM(std::span(dstVRAM), actualRowBytes, VRAMToBlit);
+
+			auto actualRowBytes = ((width >> compressed) + padding) * bpp; // add some padding so the row bytes differs from the expected
+			auto actualWidth = (width >> compressed); // in pixels
+			auto expectedRowBytes = (width >> compressed) * bpp;
+			auto dstVRAM = std::vector<uint8_t>(actualRowBytes * (VRAMToBlit.size() / (width >> 3)));
+			i8080ArcadeIO->BlitVRAM(std::span(dstVRAM), actualWidth, actualRowBytes, VRAMToBlit, 256 >> 3);
 
 			auto expected = expectedVRAM.data();
 			auto actual = dstVRAM.data();
 			while(expected < expectedVRAM.data() + expectedVRAM.size())
 			{
-				TEST_ASSERT_EQUAL_MEMORY(expected, actual, expectedRowBytes);
+				TEST_ASSERT_EQUAL_MEMORY(actual, expected, expectedRowBytes);
 				actual += actualRowBytes;
 				expected += expectedRowBytes;
 			}
@@ -302,45 +305,62 @@ namespace meen_hw::tests
 
 		// Set the src vram to be blitted to be an alternating black and white scanline pattern
 		// This will act as the expectedVRAM for 1bpp native orientation test
-		for (auto data = srcVRAM; data < srcVRAM + 7168; data += 64)
+		for (auto data = srcVRAM.begin(); data < srcVRAM.end()/* + 7168*/; std::advance(data, 64)/*data += 64*/)
 		{
 			// 32 - compressed row bytes
-			std::fill_n(data, 32, 0x00);
+			std::ranges::fill_n(data, 32, 0x00);
 			std::fill_n(data + 32, 32, 0xFF);
 		}
 
 		// Native blit without padding
-		checkVRAM(std::span(srcVRAM), std::span(srcVRAM), 32, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(srcVRAM), 32, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
 		// Native blit with padding
-		checkVRAM(std::span(srcVRAM), std::span(srcVRAM), 32, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
+		checkVRAM(std::span(srcVRAM), 256, std::span(srcVRAM), 32, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"cocktail\"}");
 
 		// Vertical black and white bars
-		std::fill(expectedVRAM, expectedVRAM + 7168, 0xAA);
-
+		std::ranges::fill(expectedVRAM.begin(), expectedVRAM.begin() + 7168, 0xAA);
 		// Native bpp blit with upright orientation without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 7168), 28, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 7168), 28, 1, 0, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
 		// Native bpp blit with upright orientation with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM, 7168), 28, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 7168), 28, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
 
-		for (auto data = expectedVRAM; data < expectedVRAM + 57344; data += 512)
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.begin() + 57344; std::advance(data, 512))//data += 512)
 		{
-			// 256 - uncompressed row bytes
-			std::fill_n(data, 256, 0x00);
-			std::fill_n(data + 256, 256, 0xFF);
+			// 256 - 8bpp uncompressed row bytes
+			std::ranges::fill_n(data, 256, 0x00);
+			std::ranges::fill_n(data + 256, 256, 0xFF);
 		}
-		
-		// Native orientation 8pp blit without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 256, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
-		// Native orientation 8pp blit with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 256, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
 
-		auto data = expectedVRAM;
-		std::fill_n(std::bit_cast<uint16_t*>(data), 28672, 0xFF00);
+		// Native orientation 8pp blit without padding
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM.begin(), 57344), 256, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
+		// Native orientation 8pp blit with padding
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM.begin(), 57344), 256, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"cocktail\"}");
+
+		std::ranges::fill_n(std::bit_cast<uint16_t*>(expectedVRAM.data()), 28672, 0xFF00);
 
 		// 8 bpp blit with upright orientation without padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 224, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 57344), 224, 1, 0, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
 		// 8 bpp blit with upright orientation with padding
-		checkVRAM(std::span(srcVRAM), std::span(expectedVRAM), 224, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 57344), 224, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
+
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.end()/* + 114688*/; std::advance(data, 1024))//data += 1024)
+		{
+			// 512 - 16bpp uncompressed row bytes
+			std::ranges::fill_n(data, 512, 0x00);
+			std::ranges::fill_n(data + 512, 512, 0xFF);
+		}
+
+		// Native orientation 16pp blit without padding
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM), 256, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"cocktail\"}");
+		// Native orientation 16pp blit with padding
+		checkVRAM(std::span(srcVRAM), 256, std::span(expectedVRAM), 256, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"cocktail\"}");
+
+		std::ranges::fill_n(std::bit_cast<uint32_t*>(expectedVRAM.data()), 28672, 0xFFFF0000);
+
+		// 16 bpp blit with upright orientation without padding
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM), 224, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
+		// 16 bpp blit with upright orientation with padding
+		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM), 224, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
 	}
 #endif
 } // namespace meen_hw::tests
@@ -364,7 +384,6 @@ int main(void)
 		RUN_TEST(meen_hw::tests::test_ShiftRegister);
 		RUN_TEST(meen_hw::tests::test_GenerateInterrupt);
 		RUN_TEST(meen_hw::tests::test_SetOptions);
-		RUN_TEST(meen_hw::tests::test_GetVRAMDimensions);
 		RUN_TEST(meen_hw::tests::test_BlitVRAM);
 #endif
 		err = meen_hw::tests::suiteTearDown(UNITY_END());

--- a/tests/meen_hw_test/source/MeenHwUnityTest.cpp
+++ b/tests/meen_hw_test/source/MeenHwUnityTest.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021-2024 Nicolas Beddows <nicolas.beddows@gmail.com>
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -274,16 +274,20 @@ namespace meen_hw::tests
 
 	void test_BlitVRAM()
 	{
-		std::vector<uint8_t> srcVRAM(7168);//[7168]; // 7168 - width * height @ 1bpp
-		//std::vector<uint8_t> expectedVRAM(57344); // 57344 - width * height @ 8pp
-		std::vector<uint8_t> expectedVRAM(114688);//[114688]; // 57344 - width * height @ 16pp
+		std::vector<uint8_t> srcVRAM(7168); // 7168 - width * height @ 1bpp
 
+// todo: need to perform a 16 bit test that uses less memory
+#ifdef ENABLE_MH_RP2040
+		std::vector<uint8_t> expectedVRAM(57344); // 57344 - width * height @ 8pp
+#else
+		std::vector<uint8_t> expectedVRAM(114688); // 114688 - width * height @ 16pp
+#endif // ENABLE_MH_RP2040
 		auto checkVRAM = [](std::span<uint8_t> VRAMToBlit, int width, std::span<uint8_t> expectedVRAM, int expectedWidth, int bpp, int padding, int compressed, const char* options)
 		{
 			// Blit to native format
 			TEST_ASSERT_FALSE(i8080ArcadeIO->SetOptions(options));
-			// To get the row bytes we need to shift down 3 (divide by 8) if we are compressed, 0 if we are uncompressed.
 
+			// To get the row bytes we need to shift down 3 (divide by 8) if we are compressed, 0 if we are uncompressed.
 			auto actualRowBytes = ((width >> compressed) + padding) * bpp; // add some padding so the row bytes differs from the expected
 			auto actualWidth = (width >> compressed); // in pixels
 			auto expectedRowBytes = (width >> compressed) * bpp;
@@ -305,7 +309,7 @@ namespace meen_hw::tests
 
 		// Set the src vram to be blitted to be an alternating black and white scanline pattern
 		// This will act as the expectedVRAM for 1bpp native orientation test
-		for (auto data = srcVRAM.begin(); data < srcVRAM.end()/* + 7168*/; std::advance(data, 64)/*data += 64*/)
+		for (auto data = srcVRAM.begin(); data < srcVRAM.end(); std::advance(data, 64))
 		{
 			// 32 - compressed row bytes
 			std::ranges::fill_n(data, 32, 0x00);
@@ -324,7 +328,7 @@ namespace meen_hw::tests
 		// Native bpp blit with upright orientation with padding
 		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 7168), 28, 1, 2, 3, "{\"bpp\":1,\"orientation\":\"upright\"}");
 
-		for (auto data = expectedVRAM.begin(); data < expectedVRAM.begin() + 57344; std::advance(data, 512))//data += 512)
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.begin() + 57344; std::advance(data, 512))
 		{
 			// 256 - 8bpp uncompressed row bytes
 			std::ranges::fill_n(data, 256, 0x00);
@@ -343,7 +347,9 @@ namespace meen_hw::tests
 		// 8 bpp blit with upright orientation with padding
 		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM.begin(), 57344), 224, 1, 16, 0, "{\"bpp\":8,\"orientation\":\"upright\"}");
 
-		for (auto data = expectedVRAM.begin(); data < expectedVRAM.end()/* + 114688*/; std::advance(data, 1024))//data += 1024)
+// todo: need to perform a 16 bit test that uses less memory
+#ifndef ENABLE_MH_RP2040
+		for (auto data = expectedVRAM.begin(); data < expectedVRAM.end(); std::advance(data, 1024))
 		{
 			// 512 - 16bpp uncompressed row bytes
 			std::ranges::fill_n(data, 512, 0x00);
@@ -361,6 +367,7 @@ namespace meen_hw::tests
 		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM), 224, 2, 0, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
 		// 16 bpp blit with upright orientation with padding
 		checkVRAM(std::span(srcVRAM), 224, std::span(expectedVRAM), 224, 2, 16, 0, "{\"bpp\":16,\"orientation\":\"upright\"}");
+#endif // ENABLE_MH_RP2040
 	}
 #endif
 } // namespace meen_hw::tests


### PR DESCRIPTION
- The `BlitVRAM` method has been updated so that it can blit to destination buffers of varying dimensions.
- Fixed a bug where parsing the `colour` option `blue` would fail
- The set options unit test has wider coverage.
- Removed superfluous methods `GetVRAMWidth` and `GetVRAMHeight`.
