### PR TITLE
#38 feat: reset interface method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   from sources to destinations of varying dimensions.
 * Fixed a bug where parsing the `colour` option `blue`
   would fail.
+* Add the interface method `MH_I8080ArcadeIO::Reset`
+  to reset the non-configurable state.
 
 0.2.1 [04/09/24]
 * Updated the install instructions for new meen

--- a/include/meen_hw/MH_II8080ArcadeIO.h
+++ b/include/meen_hw/MH_II8080ArcadeIO.h
@@ -83,7 +83,9 @@ namespace meen_hw
 
 			@param		port		The input device to read from.
 
-			@return		uint8_t		Non zero if the port was read from, zero otherwise.
+			@remark		Must be called from the same thread as WritePort.
+
+			@return		Non zero if the port was read from, zero otherwise.
 		*/
 		virtual uint8_t ReadPort(uint16_t port) = 0;
 
@@ -123,6 +125,8 @@ namespace meen_hw
 			@param	port		The output device to write to.
 			@param	data		The data to write to the output device.
 
+			@remark				Must be called from the same thread as ReadPort.
+
 			@return				Audio that requires rendering as described above.
 		*/
 		virtual uint8_t WritePort(uint16_t port, uint8_t data) = 0;
@@ -134,11 +138,23 @@ namespace meen_hw
 			This informs the ROM that it is safe to draw to the
 			top and bottom of the video ram.
 
+			@remark				Must be called from the same thread as Reset.
+
 			@return				0: no interrupt has occured.
 								1: the 'beam' is near the centre of the screen.
 								2: the 'beam' is at the end (vBlank). 
 		*/
 		virtual uint8_t GenerateInterrupt(uint64_t currTime, uint64_t cycles) = 0;
+
+		/** Reset the non-configurable state
+		
+			Reset the internal state (not the state that can be configured via the SetOptions method)
+			to that of when this instance was first instantiated.
+
+			@remark				Must be called from the same thread as calls to WritePort, ReadPort and
+								GenerateInterrupt.
+		*/
+		virtual void Reset() = 0;
 
 		/** Blit options
 
@@ -151,6 +167,8 @@ namespace meen_hw
 									bpp: [1(default)|8|16] - the pixel format is determined by the calling application. 
 									colour: ["white"(default)|"red"|"green"|"blue"|"random"|hex]
 									orientation: ["cocktail"(default)|"upright"]
+
+			@remark					Must be called from the same thread as BlitVRAM.
 		*/
 		virtual std::error_code SetOptions(const char* options) = 0;
 
@@ -163,6 +181,7 @@ namespace meen_hw
 			@param	srcVRAM			The video ram to copy.
 
 			@remark					The srcVRAM is assumed to be contiguous without padding.
+			@remark					Must be called from the same thread as SetOptions.
 		*/
 		virtual void BlitVRAM(std::span<uint8_t> dst, int dstWidth, int dstRowBytes, std::span<uint8_t> src, int srcWidth) = 0;
 

--- a/include/meen_hw/i8080_arcade/MH_I8080ArcadeIO.h
+++ b/include/meen_hw/i8080_arcade/MH_I8080ArcadeIO.h
@@ -140,6 +140,12 @@ namespace meen_hw::i8080_arcade
 		*/
 		uint8_t GenerateInterrupt(uint64_t currTime, uint64_t cycles) final;
 
+		/** Reset the internal state
+
+			@see MH_II8080ArcadeIO::Reset
+		*/
+		void Reset() final;
+
 		/** Write i8080 arcade vram to texture
 		
 			@see MH_II8080ArcadeIO::BlitVRAM

--- a/source/i8080_arcade/MH_I8080ArcadeIO.cpp
+++ b/source/i8080_arcade/MH_I8080ArcadeIO.cpp
@@ -64,7 +64,7 @@ namespace meen_hw::i8080_arcade
 		else if (port == 3)
 		{
 			// Ufo audio repeats, so we'll handle that as a separate case
-			audio[0] = (data & 1) | (port3Byte_ & 1);
+			audio[0] = data & 1;
 
 			for (int i = 1; i < 8; i++)
 			{
@@ -124,6 +124,17 @@ namespace meen_hw::i8080_arcade
 		}
 
 		return isr;
+	}
+
+	void MH_I8080ArcadeIO::Reset()
+	{
+		lastTime_ = 0;
+		nextInterrupt_ = 1;
+		port3Byte_ = 0;
+		port5Byte_ = 0;
+		shiftAmount_ = 0;
+		shiftData_ = 0;
+		shiftIn_ = 0;
 	}
 
 	void MH_I8080ArcadeIO::BlitVRAM(std::span<uint8_t> dst, int dstWidth, int dstRowBytes, std::span<uint8_t> src, int srcWidth)

--- a/tests/meen_hw_test/source/MeenHwGTest.cpp
+++ b/tests/meen_hw_test/source/MeenHwGTest.cpp
@@ -182,10 +182,6 @@ namespace meen_hw::tests
 		value = i8080ArcadeIO_->WritePort(3, 0x03);
 		// We should get audio sound effect 1 again but not 2
 		EXPECT_EQ(0x01, value);
-		// End the repeating effect (it should play out one more time)
-		value = i8080ArcadeIO_->WritePort(3, 0x00);
-		// We should get audio sound effect 1 again
-		EXPECT_EQ(0x01, value);
 		// Don't play any audio sound effects
 		value = i8080ArcadeIO_->WritePort(3, 0x00);
 		// We should get nothing back

--- a/tests/meen_hw_test/source/MeenHwUnityTest.cpp
+++ b/tests/meen_hw_test/source/MeenHwUnityTest.cpp
@@ -187,10 +187,6 @@ namespace meen_hw::tests
 		value = i8080ArcadeIO->WritePort(3, 0x03);
 		// We should get audio sound effect 1 again but not 2
 		TEST_ASSERT_EQUAL_UINT8(0x01, value);
-		// End the repeating effect (it should play out one more time)
-		value = i8080ArcadeIO->WritePort(3, 0x00);
-		// We should get audio sound effect 1 again
-		TEST_ASSERT_EQUAL_UINT8(0x01, value);
 		// Don't play any audio sound effects
 		value = i8080ArcadeIO->WritePort(3, 0x00);
 		// We should get nothing back


### PR DESCRIPTION
- Added the method `Reset` which resets the non-configurable state.
- Removed the reliance on the previous audio byte for repeating sounds and removed the unit test for this.