### PR TITLE
#46: fix meen hardware package name for release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,5 +115,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: ReleaseNotes.md
-          files: ${{ matrix.package_dir }}/meen-hw*.tar.gz
+          files: ${{ matrix.package_dir }}/meen_hw*.tar.gz
           generate_release_notes: true


### PR DESCRIPTION
- Fix incorrect package name for GitHub CI/CD release workflow.