### PR TITLE
#51 feat: resource pool wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Added MH_ResourcePool::Wait method.
+* Added MH_ResourcePool::GetSize method.
+
 0.4.0 [26/07/25]
 * Added testing and release workflows for GitHub Actions CI/CD.
 * Dropped GCC-12 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 * Added MH_ResourcePool::Wait method.
 * Added MH_ResourcePool::GetSize method.
+* Added MH_ResourcePool::GetAvailable method.
+* Added MH_ConditionVariable which wraps supported
+  platform implementations.
 
 0.4.0 [26/07/25]
 * Added testing and release workflows for GitHub Actions CI/CD.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,8 @@ set (${lib_name}_private_include_files
 )
 
 set (${lib_name}_public_include_files
-	${include_dir}/${lib_name}/MH_Error.h
+  ${include_dir}/${lib_name}/MH_ConditionVariable.h
+  ${include_dir}/${lib_name}/MH_Error.h
   ${include_dir}/${lib_name}/MH_Factory.h
   ${include_dir}/${lib_name}/MH_II8080ArcadeIO.h
   ${include_dir}/${lib_name}/MH_Mutex.h

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,10 +1,8 @@
-## MEEN HardWare 0.4.0
+## MEEN HardWare 0.5.0
 
 **Highlights:**
 
-- GitHub Actions CI/CD support.
-- GCC-14 support.
-- Pico SDK 2.x.x support.
-- GTest latest version update.
+- Added MH_ResourcePool::Wait method.
+- Added MH_ConditionVariable header.
 
 See the CHANGELOG for a complete list.

--- a/include/meen_hw/MH_ConditionVariable.h
+++ b/include/meen_hw/MH_ConditionVariable.h
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2021-2025 Nicolas Beddows <nicolas.beddows@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef MEEN_HW_MH_CONDITIONVARIABLE_H
+#define MEEN_HW_MH_CONDITIONVARIABLE_H
+
+#include <functional>
+
+#ifdef PICO_BOARD
+	using mh_cv = int;
+	// We have no condition variable on pico, so we just use a spin lock
+	#define MH_CV_WAIT(ul, p) while(p() == false);
+	#define MH_CV_NOTIFY_ONE()
+#else // use std::mutex
+	#include <condition_variable>
+
+	#include "meen_hw/MH_Mutex.h"
+
+	using mh_cv = std::condition_variable;
+
+	#define MH_CV_WAIT(ul, p) cv_.wait(ul, p); // to ignore spurious awakenings: while (!p()) cv_.wait(m);
+	#define MH_CV_NOTIFY_ONE() cv_.notify_one();
+#endif // PICO_BOARD
+
+namespace meen_hw
+{
+	/** Condition Variable wrapper
+
+		A class which wraps all the supported condition variable types.
+		The condition variable type (mh_cv) is dependent on the platform being targeted.
+		Supported condition variable types are std::condition_variable and spin lock on pico (no condition variable support ... I don't think).
+	*/
+	class MH_ConditionVariable
+	{
+	private:
+		mh_cv cv_;
+	public:
+		/** Default constructor
+
+			Construct a condition variable whose type is platform dependent.
+		*/
+		MH_ConditionVariable() = default;
+
+		/** Destructor
+
+			Use a default destructor.
+		*/
+		~MH_ConditionVariable() = default;
+
+		/** Wait on the condition being satisfied
+
+			Block the current thread until the condition variable is notified or a spurious wakeup occurs.
+		*/
+		void wait(mh_unique_lock& lock, std::function<bool()>&& predicate)
+		{
+			MH_CV_WAIT(lock, predicate);
+		}
+
+		/** Unblock one waiting thread
+
+			If any threads are waiting on *this, calling notify_one unblocks one of the waiting threads.
+		*/
+		void notify_one()
+		{
+			return MH_CV_NOTIFY_ONE();
+		}
+	};
+} // namespace meen_hw
+
+#endif // MEEN_HW_MH_CONDITIONVARIABLE_H

--- a/include/meen_hw/MH_ConditionVariable.h
+++ b/include/meen_hw/MH_ConditionVariable.h
@@ -25,65 +25,106 @@ SOFTWARE.
 
 #include <functional>
 
+#include "meen_hw/MH_Mutex.h"
+
 #ifdef PICO_BOARD
-	using mh_cv = int;
-	// We have no condition variable on pico, so we just use a spin lock
-	#define MH_CV_WAIT(ul, p) while(p() == false);
-	#define MH_CV_NOTIFY_ONE()
-#else // use std::mutex
-	#include <condition_variable>
-
-	#include "meen_hw/MH_Mutex.h"
-
-	using mh_cv = std::condition_variable;
-
-	#define MH_CV_WAIT(ul, p) cv_.wait(ul, p); // to ignore spurious awakenings: while (!p()) cv_.wait(m);
-	#define MH_CV_NOTIFY_ONE() cv_.notify_one();
+    #include <pico/sync.h>
+#else // use std::condition_variable
+    #include <condition_variable>
 #endif // PICO_BOARD
 
 namespace meen_hw
 {
-	/** Condition Variable wrapper
+#ifdef PICO_BOARD
+    /** Pico Condition Variable implementation
 
-		A class which wraps all the supported condition variable types.
-		The condition variable type (mh_cv) is dependent on the platform being targeted.
-		Supported condition variable types are std::condition_variable and spin lock on pico (no condition variable support ... I don't think).
-	*/
-	class MH_ConditionVariable
-	{
-	private:
-		mh_cv cv_;
-	public:
-		/** Default constructor
+        As of time of writing, the pico sdk (v2.1.1) does not have support for condition variable.
+        This is a basic implementation using mutex and semaphore which implements the required
+        methods of std::condition_variable_any.
+    */
+    class MH_ConditionVariable
+    {
+    private:
+        semaphore_t sem;
+        critical_section_t cs;
+        int waiter_count = 0;
+    public:
+        MH_ConditionVariable()
+        {
+            critical_section_init(&cs);
+            sem_init(&sem, 0, 1);
+        }
 
-			Construct a condition variable whose type is platform dependent.
-		*/
-		MH_ConditionVariable() = default;
+        ~MH_ConditionVariable()
+        {
+            critical_section_deinit(&cs);
+        }
 
-		/** Destructor
+        /** Wait on the condition being satisfied
 
-			Use a default destructor.
-		*/
-		~MH_ConditionVariable() = default;
+            Block the current thread until the condition variable is notified or a spurious wakeup occurs.
 
-		/** Wait on the condition being satisfied
+            @param	mutex		A mutex implementation that satisfies BasicLockable.
+            @param	predicate	A method that is called to detect spurious wakeups.
+        */
+        void wait(MH_Mutex& mutex, std::function<bool()>&& predicate)
+        {
+            while (predicate() == false)
+            {
+                // Count this waiter
+                critical_section_enter_blocking(&cs);
+                waiter_count++;
+                critical_section_exit(&cs);
 
-			Block the current thread until the condition variable is notified or a spurious wakeup occurs.
-		*/
-		void wait(mh_unique_lock& lock, std::function<bool()>&& predicate)
-		{
-			MH_CV_WAIT(lock, predicate);
-		}
+                mutex.unlock();
+                // Block until signaled
+                sem_acquire_blocking(&sem);
+                // Reacquire mutex before checking predicate
+                mutex.lock();
+            }
+        }
 
-		/** Unblock one waiting thread
+        /** Unblock one waiting thread
 
-			If any threads are waiting on *this, calling notify_one unblocks one of the waiting threads.
-		*/
-		void notify_one()
-		{
-			return MH_CV_NOTIFY_ONE();
-		}
-	};
+            If any threads are waiting on *this, calling notify_one unblocks one of the waiting threads.
+        */
+        void notify_one()
+        {
+            critical_section_enter_blocking(&cs);
+
+            if (waiter_count > 0)
+            {
+                waiter_count--;
+                sem_release(&sem);
+            }
+
+            critical_section_exit(&cs);
+        }
+
+        /** Unblocks all waiting threads
+
+            If any threads are waiting on *this, calling notify_all unblocks all of the waiting threads.
+        */
+        void notify_all()
+        {
+            critical_section_enter_blocking(&cs);
+
+            while (waiter_count > 0)
+            {
+                waiter_count--;
+                sem_release(&sem);
+            }
+
+            critical_section_exit(&cs);
+        }
+    };
+#else
+    /** Default platform case for condition variable
+
+        The default implementation will be std::condition_variable_any.
+    */
+    using MH_ConditionVariable = std::condition_variable_any;
+#endif // PICO_BOARD
 } // namespace meen_hw
 
 #endif // MEEN_HW_MH_CONDITIONVARIABLE_H

--- a/include/meen_hw/MH_Mutex.h
+++ b/include/meen_hw/MH_Mutex.h
@@ -25,39 +25,22 @@ SOFTWARE.
 
 #ifdef PICO_BOARD
 	#include <pico/mutex.h>
-	using mh_mutex = mutex_t;
-	// currently not supported, just make it a dupe of mutex_t
-	using mh_unique_lock = mh_mutex;
-
-	#define MH_MUTEX_INIT(m) mutex_init(&m)
-	#define MH_MUTEX_LOCK(m) mutex_enter_blocking(&m)
-	#define MH_MUTEX_TRY_LOCK(m) mutex_try_enter(&m, nullptr)
-	#define MH_MUTEX_UNLOCK(m) mutex_exit(&m)
-	#define MH_UNIQUE_LOCK(m) mh_unique_lock(m)
 #else // use std::mutex
 	#include <mutex>
-	using mh_mutex = std::mutex;
-	using mh_unique_lock = std::unique_lock<mh_mutex>;
-
-	#define MH_MUTEX_INIT(m)
-	#define MH_MUTEX_LOCK(m) m.lock()
-	#define MH_MUTEX_TRY_LOCK(m) m.try_lock()
-	#define MH_MUTEX_UNLOCK(m) m.unlock()
-	#define MH_UNIQUE_LOCK(m) mh_unique_lock(m)
 #endif // PICO_BOARD
 
 namespace meen_hw
 {
-	/** Mutex wrapper
+#ifdef PICO_BOARD
+	/** Pico recursive mutex wrapper
 
-		A class which wraps all the supported mutex types.
-		The mutex type (mh_mutex) is dependent on the platform being targeted.
-		Supported mutex types are std::mutex and pico mutex.
+		This is a simple wrapper around pico recursive mutex which adheres to basic lockable
+		and whose methods align with std::recursive_mutex
 	*/
 	class MH_Mutex
 	{
 	private:
-		mh_mutex mtx_;
+		recursive_mutex_t mtx_;
 	public:
 		/** Default constructor
 
@@ -65,7 +48,7 @@ namespace meen_hw
 		*/
 		MH_Mutex()
 		{
-			MH_MUTEX_INIT(mtx_);
+			recursive_mutex_init(&mtx_);
 		}
 
 		/** Destructor
@@ -78,9 +61,9 @@ namespace meen_hw
 
 			This will block until the mutex is acquired.
 		*/
-		void lock()
+		inline void lock()
 		{
-			MH_MUTEX_LOCK(mtx_);
+			recursive_mutex_enter_blocking(&mtx_);
 		}
 
 		/** Acquire the mutex
@@ -89,31 +72,23 @@ namespace meen_hw
 
 			@return		True if the mutex was acquired, false otherwise.
 		*/
-		bool try_lock()
+		inline bool try_lock()
 		{
-			return MH_MUTEX_TRY_LOCK(mtx_);
+			return recursive_mutex_try_enter(&mtx_, nullptr);
 		}
 
 		/** Release the mutex
 
 			Allow other threads a change to acquire this mutex.
 		*/
-		void unlock()
+		inline void unlock()
 		{
-			MH_MUTEX_UNLOCK(mtx_);
-		}
-
-		/**	Create a lock that owns the private mutex
-
-			General purpose mutex ownership wrapper.
-
-			@remark		required by condition variable.
-		*/
-		mh_unique_lock unique_lock()
-		{
-			return MH_UNIQUE_LOCK(mtx_);
+			recursive_mutex_exit(&mtx_);
 		}
 	};
+#else
+	using MH_Mutex = std::recursive_mutex;
+#endif // PICO_BOARD
 
 	/** A simple lock guard implementation
 

--- a/include/meen_hw/MH_Mutex.h
+++ b/include/meen_hw/MH_Mutex.h
@@ -26,19 +26,24 @@ SOFTWARE.
 #ifdef PICO_BOARD
 	#include <pico/mutex.h>
 	using mh_mutex = mutex_t;
+	// currently not supported, just make it a dupe of mutex_t
+	using mh_unique_lock = mh_mutex;
 
 	#define MH_MUTEX_INIT(m) mutex_init(&m)
 	#define MH_MUTEX_LOCK(m) mutex_enter_blocking(&m)
 	#define MH_MUTEX_TRY_LOCK(m) mutex_try_enter(&m, nullptr)
 	#define MH_MUTEX_UNLOCK(m) mutex_exit(&m)
+	#define MH_UNIQUE_LOCK(m) mh_unique_lock(m)
 #else // use std::mutex
 	#include <mutex>
 	using mh_mutex = std::mutex;
+	using mh_unique_lock = std::unique_lock<mh_mutex>;
 
 	#define MH_MUTEX_INIT(m)
 	#define MH_MUTEX_LOCK(m) m.lock()
 	#define MH_MUTEX_TRY_LOCK(m) m.try_lock()
 	#define MH_MUTEX_UNLOCK(m) m.unlock()
+	#define MH_UNIQUE_LOCK(m) mh_unique_lock(m)
 #endif // PICO_BOARD
 
 namespace meen_hw
@@ -96,6 +101,17 @@ namespace meen_hw
 		void unlock()
 		{
 			MH_MUTEX_UNLOCK(mtx_);
+		}
+
+		/**	Create a lock that owns the private mutex
+
+			General purpose mutex ownership wrapper.
+
+			@remark		required by condition variable.
+		*/
+		mh_unique_lock unique_lock()
+		{
+			return MH_UNIQUE_LOCK(mtx_);
 		}
 	};
 

--- a/include/meen_hw/MH_ResourcePool.h
+++ b/include/meen_hw/MH_ResourcePool.h
@@ -49,11 +49,11 @@ namespace meen_hw
 	{
     private:
         /** Resource pool mutex
-        
+
             A resource can be returned to the resource pool from any thread. This is the mutex
             used for mutual exclusion between that thread and the thread that this resource pool
             uses for resource access.
-        
+
             @remark     marked as mutable so GetResource can remain const
         */
         mutable std::shared_ptr<MH_Mutex> resourceMutex_;
@@ -67,7 +67,7 @@ namespace meen_hw
         std::shared_ptr<MH_ConditionVariable> conditionVariable_;
 
         /** Resource pool
-        
+
             A pool of resources.
 
             @remark     A resource is automatically returned to the resource pool when it is destructed.
@@ -83,7 +83,7 @@ namespace meen_hw
         int resourceCount_{};
 
         /** Custom resource deleter
-        
+
             A deleter that is attached to each resource that allows it to be returned to the resource pool
             once it has been destructed.
         */
@@ -91,7 +91,7 @@ namespace meen_hw
         {
         private:
             /** resourcePool_
-            
+
                 A weak pointer to MH_ResourcePool::resourcePool that can be used to check
                 if the resource pool is still alive. When it is alive the destructed frame will
                 be returned to it, otherwise it will be deleted.
@@ -99,9 +99,9 @@ namespace meen_hw
                 @see    MH_ResourcePool::resourcePool_
             */
             std::weak_ptr<std::list<std::unique_ptr<T, D>>> resourcePool_;
-            
+
             /** resourceMutex_
-            
+
                 A weak pointer to MH_ResourcePool::resourceMutex that can be used
                 to check if the resource mutex is still alive. When it is alive it will be
                 used to ensure mutual exculsion between the thread that this deleter was
@@ -123,7 +123,7 @@ namespace meen_hw
             std::weak_ptr<MH_ConditionVariable> conditionVariable_;
 
             /** Resource deleter
-            
+
                 The deleter that will be used to delete resources once the resource pool
                 is no longer required.
             */
@@ -131,7 +131,7 @@ namespace meen_hw
 
         public:
             /** Default constructor
-            
+
                 An empty deleter.
             */
             ResourceDeleter() = default;
@@ -152,7 +152,7 @@ namespace meen_hw
             }
 
             /** Custom deleter
-            
+
                 A deleter used to recycle resources.
 
                 @param      resource        The resource to recycle/destruct
@@ -162,7 +162,7 @@ namespace meen_hw
                 if(auto resourcePool = resourcePool_.lock())
                 {
                     auto resourceMutex = resourceMutex_.lock();
-                    
+
                     if(resourceMutex)
                     {
                         MH_LockGuard lg(*resourceMutex);
@@ -190,7 +190,7 @@ namespace meen_hw
 
     public:
         /** Custom resource unique_ptr with custom deleter attached
-        
+
             A using directive for convenience.
 
             @remark     When this resource is destructed it will be automatically returned to the resource pool.
@@ -218,7 +218,7 @@ namespace meen_hw
         ~MH_ResourcePool() = default;
 
         /** Wait for the resource pool to return to the specified size
-        
+
             @param      resourceCount       The size the resource pool must reach before this method returns.
 
             @remark     This is a blocking function and will cause a deadlock if only called from the same thread from which resources are being added and returned
@@ -227,7 +227,7 @@ namespace meen_hw
         std::error_code Wait(int resourceCount)
         {
             auto ul = resourceMutex_->unique_lock();
-            
+
             if (resourceCount < 0)
             {
                 return std::make_error_code(std::errc::invalid_argument);
@@ -244,7 +244,7 @@ namespace meen_hw
         }
 
         /** Populate the resource pool
-        
+
             Add an item to the resource pool.
 
             @param  resource    The resource to be added.

--- a/include/meen_hw/MH_ResourcePool.h
+++ b/include/meen_hw/MH_ResourcePool.h
@@ -77,7 +77,7 @@ namespace meen_hw
         mutable std::shared_ptr<std::list<std::unique_ptr<T, D>>> resourcePool_;
 
         /** Total resource count
-        
+
             The total number of resources that haven been added via the AddResource method.
         */
         int resourceCount_{};
@@ -113,7 +113,7 @@ namespace meen_hw
             std::weak_ptr<MH_Mutex> resourceMutex_;
 
             /** conditionVariable_
-            
+
                 A weak pointer to the MH_ResourcePool::conditionVariable that can be used
                 to check if the resource condition variable is still alive. When it is alive
                 it will call its notify_one method allowing the Wait method to re-acquire
@@ -220,27 +220,57 @@ namespace meen_hw
         /** Wait for the resource pool to return to the specified size
 
             @param      resourceCount       The size the resource pool must reach before this method returns.
+            @param      onWaitComplete      A user defined callback which is invoked under the resource pool lock
+                                            when the resource pool size reaches the value defined in the parameter
+                                            resourceCount.
 
             @remark     This is a blocking function and will cause a deadlock if only called from the same thread from which resources are being added and returned
                         to the resource pool.
         */
-        std::error_code Wait(int resourceCount)
+        std::error_code Wait(int resourceCount, std::function<void()>&& onWaitComplete)
         {
-            auto ul = resourceMutex_->unique_lock();
-
             if (resourceCount < 0)
             {
                 return std::make_error_code(std::errc::invalid_argument);
             }
 
-            conditionVariable_->wait(ul, [&]{ return resourcePool_->size() == resourceCount; });
+            MH_LockGuard lg(*resourceMutex_);
+
+            conditionVariable_->wait(*resourceMutex_, [&]
+            {
+                return resourcePool_->size() == resourceCount;
+            });
+
+            if (onWaitComplete != nullptr)
+            {
+                onWaitComplete();
+            }
+
             return std::error_code{};
         }
 
+        /** Total resource pool elements
+
+            @return The number of resources that have been added to the resource pool via AddResource.
+
+            @remark This is NOT to be confused with the current number of elements residing in the resource pool.
+        */
         int GetSize() const
         {
             MH_LockGuard lg(*resourceMutex_);
             return resourceCount_;
+        }
+
+        /** Current element count
+
+            @return The number of elements currently residing in the resource pool.
+
+            @remark This is NOT to be confused with the total number of elements added via AddResource.
+        */
+        int GetAvailable() const // Change name to GetAvailale if we require this method
+        {
+            MH_LockGuard lg(*resourceMutex_);
+            return resourcePool_->size();
         }
 
         /** Populate the resource pool

--- a/include/meen_hw/MH_ResourcePool.h
+++ b/include/meen_hw/MH_ResourcePool.h
@@ -27,6 +27,7 @@ SOFTWARE.
 #include <memory>
 #include <list>
 
+#include "meen_hw/MH_ConditionVariable.h"
 #include "meen_hw/MH_Mutex.h"
 
 namespace meen_hw
@@ -57,6 +58,14 @@ namespace meen_hw
         */
         mutable std::shared_ptr<MH_Mutex> resourceMutex_;
 
+        /** Resource pool condition variable
+
+            The calling application may need to block on one thread while another condition is satisified in another thread.
+
+            @remark Used in the Wait method to block on the resourcePool size reaching the resourceCount parameter passed to the Wait method
+        */
+        std::shared_ptr<MH_ConditionVariable> conditionVariable_;
+
         /** Resource pool
         
             A pool of resources.
@@ -66,6 +75,12 @@ namespace meen_hw
             @remark     Marked as mutable so GetResource can remain const.
         */
         mutable std::shared_ptr<std::list<std::unique_ptr<T, D>>> resourcePool_;
+
+        /** Total resource count
+        
+            The total number of resources that haven been added via the AddResource method.
+        */
+        int resourceCount_{};
 
         /** Custom resource deleter
         
@@ -87,7 +102,7 @@ namespace meen_hw
             
             /** resourceMutex_
             
-                A weak pointer to  MH_ResourcePool::resourceMutex that can be used
+                A weak pointer to MH_ResourcePool::resourceMutex that can be used
                 to check if the resource mutex is still alive. When it is alive it will be
                 used to ensure mutual exculsion between the thread that this deleter was
                 invoked from and the thread on which this resource pool is running,
@@ -96,6 +111,16 @@ namespace meen_hw
                 @see    MH_ResourcePool::resourceMutex_
             */
             std::weak_ptr<MH_Mutex> resourceMutex_;
+
+            /** conditionVariable_
+            
+                A weak pointer to the MH_ResourcePool::conditionVariable that can be used
+                to check if the resource condition variable is still alive. When it is alive
+                it will call its notify_one method allowing the Wait method to re-acquire
+                the resource mutex and check it's condition, otherwise it will it no be
+                accessed.
+            */
+            std::weak_ptr<MH_ConditionVariable> conditionVariable_;
 
             /** Resource deleter
             
@@ -118,9 +143,10 @@ namespace meen_hw
                 @param      resourcePool       The resource pool that destructed resources will be returned to.
                 @param      resourceMutex      The resource pool mutex that will be used for mutual exclusion.
             */
-            ResourceDeleter(const std::shared_ptr<std::list<std::unique_ptr<T, D>>>& resourcePool, const std::shared_ptr<MH_Mutex>& resourceMutex)
-                : resourcePool_(resourcePool)
-                , resourceMutex_{resourceMutex}
+            ResourceDeleter(const std::shared_ptr<std::list<std::unique_ptr<T, D>>>& resourcePool, const std::shared_ptr<MH_Mutex>& resourceMutex, const std::shared_ptr<MH_ConditionVariable>& conditionVariable)
+                : resourcePool_{ resourcePool }
+                , resourceMutex_{ resourceMutex }
+                , conditionVariable_{ conditionVariable }
             {
 
             }
@@ -129,7 +155,7 @@ namespace meen_hw
             
                 A deleter used to recycle resources.
 
-                @param      resource            The resource to recycle/destruct
+                @param      resource        The resource to recycle/destruct
             */
             void operator()(T* resource)
             {
@@ -146,6 +172,13 @@ namespace meen_hw
                     {
                         assert(resourceMutex != nullptr);
                         resourcePool->emplace_back(std::unique_ptr<T, D>{resource});
+                    }
+
+                    auto conditionVariable = conditionVariable_.lock();
+
+                    if (conditionVariable)
+                    {
+                        conditionVariable->notify_one();
                     }
                 }
                 else
@@ -173,20 +206,9 @@ namespace meen_hw
         */
         explicit MH_ResourcePool()
         {
+            conditionVariable_ = std::make_shared<MH_ConditionVariable>();
             resourceMutex_ = std::make_shared<MH_Mutex>();
             resourcePool_ = std::make_shared<std::list<std::unique_ptr<T, D>>>();
-        }
-
-        /** Populate the resource pool
-        
-            Add an item to the resource pool.
-
-            @param  resource    The resource to be added.
-        */
-        void AddResource(T* resource)
-        {
-            MH_LockGuard lg(*resourceMutex_);
-            resourcePool_->emplace_back(std::unique_ptr<T, D>{resource});
         }
 
         /** Destructor
@@ -194,6 +216,51 @@ namespace meen_hw
             Free the resource pool
         */
         ~MH_ResourcePool() = default;
+
+        /** Wait for the resource pool to return to the specified size
+        
+            @param      resourceCount       The size the resource pool must reach before this method returns.
+
+            @remark     This is a blocking function and will cause a deadlock if only called from the same thread from which resources are being added and returned
+                        to the resource pool.
+        */
+        std::error_code Wait(int resourceCount)
+        {
+            auto ul = resourceMutex_->unique_lock();
+            
+            if (resourceCount < 0)
+            {
+                return std::make_error_code(std::errc::invalid_argument);
+            }
+
+            conditionVariable_->wait(ul, [&]{ return resourcePool_->size() == resourceCount; });
+            return std::error_code{};
+        }
+
+        int GetSize() const
+        {
+            MH_LockGuard lg(*resourceMutex_);
+            return resourceCount_;
+        }
+
+        /** Populate the resource pool
+        
+            Add an item to the resource pool.
+
+            @param  resource    The resource to be added.
+
+            @remark             Performs a notify on the condition variable as we could be in a waiting state.
+        */
+        void AddResource(T* resource)
+        {
+            {
+                MH_LockGuard lg(*resourceMutex_);
+                resourcePool_->emplace_back(std::unique_ptr<T, D>{resource});
+                resourceCount_++;
+            }
+
+            conditionVariable_->notify_one();
+        }
 
         /** Get a resource from the resource pool
 
@@ -203,7 +270,7 @@ namespace meen_hw
         {
             std::unique_ptr<T, D> resource;
 
-            // This method is called from GenerateInterrupt so we don't 
+            // This method is called from GenerateInterrupt so we don't
             // want to block waiting for this mutex as we could stall the cpu,
             // if we don't get it, this resource will be dropped (host is too
             // slow, the machine clock resolution is too high or the function
@@ -219,7 +286,7 @@ namespace meen_hw
                 resourceMutex_->unlock();
             }
 
-            return ResourcePtr{resource.release(), ResourceDeleter{resourcePool_, resourceMutex_}};
+            return ResourcePtr{ resource.release(), ResourceDeleter{resourcePool_, resourceMutex_, conditionVariable_} };
         }
     };
 } // namespace meen_hw


### PR DESCRIPTION
Added the following methods to `MH_ResourcePool`:
- `GetSize`: returns the total number of elements allocated by the `AddResource` method.
- `GetAvailable`: returns the number of elements currently in the resource pool.
- `Wait`: waits for the resource pool element count to reach the specified size, optionally invoking a user defined callback once the wait is complete.

Added `MH_ConditionVariable` header which provides a custom implementation of condition_variable_any for rp pico and defaults to `std::condition_variable_any` on other platforms. This is required for the `MH_ResourcePool::Wait` method.

Refactored `MH_Mutex`.
